### PR TITLE
D3 v6 updates - Fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,9 +359,9 @@ class RangeSlider {
           [0, 0],
           [calc.chartWidth, calc.chartHeight],
         ])
-        .on("start", brushStarted)
-        .on("end", brushEnded)
-        .on("brush", brushed)
+        .on("start", (event) => brushStarted(event))
+        .on("end", (event) => brushEnded(event))
+        .on("brush", (event, d) => brushed(event, d))
     );
 
     attrs.brush = brush;
@@ -376,18 +376,18 @@ class RangeSlider {
 
 
 
-    function brushStarted() {
-      if (d3.event.selection) {
-        attrs.startSelection = d3.event.selection[0];
+    function brushStarted(event) {
+      if (event.selection) {
+        attrs.startSelection = event.selection[0];
       }
     }
 
-    function brushEnded() {
+    function brushEnded(event) {
       const attrs = that.getChartState();
       var minX = attrs.minX;
       var maxX = attrs.maxX;
 
-      if (!d3.event.selection) {
+      if (!event.selection) {
         handle.attr("display", "none");
 
         output({
@@ -395,9 +395,9 @@ class RangeSlider {
         });
         return;
       }
-      if (d3.event.sourceEvent.type === "brush") return;
+      if (event.sourceEvent.type === "brush") return;
 
-      var d0 = d3.event.selection.map(scaleX.invert),
+      var d0 = event.selection.map(scaleX.invert),
         d1 = d0.map(d3.timeDay.round);
 
       if (d1[0] >= d1[1]) {
@@ -406,28 +406,28 @@ class RangeSlider {
       }
     }
 
-    function brushed(d) {
-      if (d3.event.sourceEvent.type === "brush") return;
+    function brushed(event, d) {
+      if (event.sourceEvent.type === "brush") return;
       if (attrs.freezeMin) {
-        if (d3.event.selection[0] < attrs.startSelection) {
-          d3.event.selection[1] = Math.min(
-            d3.event.selection[0],
-            d3.event.selection[1]
+        if (event.selection[0] < attrs.startSelection) {
+            event.selection[1] = Math.min(
+            event.selection[0],
+            event.selection[1]
           );
         }
-        if (d3.event.selection[0] >= attrs.startSelection) {
-          d3.event.selection[1] = Math.max(
-            d3.event.selection[0],
-            d3.event.selection[1]
+        if (event.selection[0] >= attrs.startSelection) {
+            event.selection[1] = Math.max(
+            event.selection[0],
+            event.selection[1]
           );
         }
 
-        d3.event.selection[0] = 0;
-        d3.select(this).call(d3.event.target.move, d3.event.selection);
+        event.selection[0] = 0;
+        d3.select(this).call(event.target.move, event.selection);
       }
 
-      var d0 = d3.event.selection.map(scaleX.invert);
-      const s = d3.event.selection;
+      var d0 = event.selection.map(scaleX.invert);
+      const s = event.selection;
 
       handle.attr("display", null).attr("transform", function (d, i) {
         return "translate(" + (s[i] - 2) + "," + (calc.chartHeight / 2 - 25) + ")";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-driven-range-slider",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "d3.js based data driven range slider",
   "main": "index.js",
   "scripts": {
@@ -19,8 +19,8 @@
     "angular-range-slider",
     "vue-range-slider"
   ],
-  "dependencies": {
-    "d3": "*"
+  "peerDependencies": {
+    "d3": ">=6"
   },
   "author": "David B.",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-driven-range-slider",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "d3.js based data driven range slider",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In v6 of d3, events were updated to remove the global "d3.event" and pass the event content itself. This pull request updates the data-driven-range-slider to use the new syntax.

Updated version to 2.0.0 since you now need a specific version of d3. Updated to peerDependency so projects won't have multiple versions of d3 installed in node_modules.